### PR TITLE
docs(env): clarify acme DEFAULT_EMAIL vs per-container LETSENCRYPT_EMAIL

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,4 @@
+# nginx-proxy / acme-companion: leave LETSENCRYPT_EMAIL empty when userver-web sets DEFAULT_EMAIL once.
 VIRTUAL_HOST=
 LETSENCRYPT_HOST=
 LETSENCRYPT_EMAIL=


### PR DESCRIPTION
Document that repeating the same email on many containers breaks ACME when using userver-web nginx-proxy / acme-companion (addresses get concatenated).

Made-with: Cursor